### PR TITLE
feat! option to use GPS pricing instead of distance pricing

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -164,8 +164,6 @@ local function callNpcPoly()
                     meterIsOpen = true
                     meterActive = true
 
-                    pickupLocation = GetEntityCoords(cache.ped)
-                    dropOffLocation = config.pzLocations.dropLocations[NpcData.CurrentDeliver].coord.xyz
                     lastLocation = GetEntityCoords(cache.ped)
                     SendNUIMessage({
                         action = 'openMeter',

--- a/client/main.lua
+++ b/client/main.lua
@@ -7,6 +7,7 @@ local meterActive = false
 local lastLocation = nil
 local mouseActive = false
 local garageZone, taxiParkingZone = nil, nil
+local pickupLocation, dropOffLocation = nil, nil
 
 -- used for polyzones
 local isInsidePickupZone = false
@@ -120,6 +121,9 @@ local function getDeliveryLocation()
                             SendNUIMessage({
                                 action = 'resetMeter'
                             })
+
+                            pickupLocation, pickupLocation = nil, nil
+
                             exports.qbx_core:Notify(locale('info.person_was_dropped_off'), 'success')
                             if NpcData.DeliveryBlip then
                                 RemoveBlip(NpcData.DeliveryBlip)
@@ -159,6 +163,9 @@ local function callNpcPoly()
 
                     meterIsOpen = true
                     meterActive = true
+
+                    pickupLocation = GetEntityCoords(cache.ped)
+                    dropOffLocation = config.pzLocations.dropLocations[NpcData.CurrentDeliver].coord.xyz
                     lastLocation = GetEntityCoords(cache.ped)
                     SendNUIMessage({
                         action = 'openMeter',
@@ -263,8 +270,17 @@ local function calculateFareAmount()
 
             meterData['distanceTraveled'] += (newDistance / 1609)
 
-            local fareAmount = ((meterData['distanceTraveled']) * config.meter.defaultPrice) + config.meter.startingPrice
+            local fareAmount = 0
+
+            if(config.meter.useGpsPrice) then
+                local distanceBetweenPickupAndDropoff = CalculateTravelDistanceBetweenPoints(pickupLocation.x, pickupLocation.y, pickupLocation.z, dropOffLocation.x, dropOffLocation.y, dropOffLocation.z) / 1609 -- Convert to miles
+                fareAmount =  (distanceBetweenPickupAndDropoff * config.meter.defaultPrice) + config.meter.startingPrice
+            else 
+                fareAmount = ((meterData['distanceTraveled']) * config.meter.defaultPrice) + config.meter.startingPrice
+            end
+
             meterData['currentFare'] = math.floor(fareAmount)
+
 
             SendNUIMessage({
                 action = 'updateMeter',
@@ -545,6 +561,8 @@ RegisterNetEvent('qb-taxi:client:DoTaxiNpc', function()
                                         end
                                     end
 
+                                    pickupLocation = GetEntityCoords(cache.ped)
+
                                     meterIsOpen = true
                                     meterActive = true
                                     lastLocation = GetEntityCoords(cache.ped)
@@ -564,6 +582,7 @@ RegisterNetEvent('qb-taxi:client:DoTaxiNpc', function()
                                         RemoveBlip(NpcData.NpcBlip)
                                     end
                                     getDeliveryLocation()
+                                    dropOffLocation = config.pzLocations.dropLocations[NpcData.CurrentDeliver].coord.xyz
                                     NpcData.NpcTaken = true
                                 end
                             end

--- a/config/client.lua
+++ b/config/client.lua
@@ -7,7 +7,8 @@ return {
     },
     meter = {
         defaultPrice = 125.0, -- price per mile
-        startingPrice = 0     -- static starting price
+        startingPrice = 0,     -- static starting price
+        useGpsPrice = true -- use GPS distance instead of driven distance
     },
     locations = {
         main = {


### PR DESCRIPTION
## Description

Fixes the exploit where players can drive around infinitely and rack up insane amounts of money by using GPS distance pricing. (#5)
- Adds a config option to use this system or the old driving distance system
- Uses CALCULATE_TRAVEL_DISTANCE_BETWEEN_POINTS to calculate the GPS distance (seems to line up **most** times with GPS distance, other times it's kinda off)

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions. (I hope so)
